### PR TITLE
Add FuseSoC support and github CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: build-openlane-sky130
+on: [push]
+
+jobs:
+  build-aes:
+    runs-on: ubuntu-latest
+    env:
+      REPO : aes
+      VLNV : secworks:crypto:aes
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: aes
+      - name: Checkout pdk
+        uses: actions/checkout@v2
+        with:
+          repository: olofk/pdklite
+          path: pdklite
+      - run: echo "PDK_ROOT=$GITHUB_WORKSPACE/pdklite" >> $GITHUB_ENV
+      - run: echo "EDALIZE_LAUNCHER=${GITHUB_WORKSPACE}/$REPO/.github/workflows/openlane_runner.py" >> $GITHUB_ENV
+      - run: pip3 install --user -e "git+https://github.com/olofk/edalize.git#egg=edalize"
+      - run: pip3 install fusesoc
+#      - run: docker pull efabless/openlane:v0.12
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV
+
+  sim-icarus:
+    runs-on: ubuntu-latest
+    env:
+      REPO : aes
+      VLNV : secworks:crypto:aes
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: aes
+      - run: sudo apt install iverilog
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=tb_aes_core $VLNV
+      - run: fusesoc run --target=tb_aes_decipher_block $VLNV
+      - run: fusesoc run --target=tb_aes_encipher_block $VLNV
+      - run: fusesoc run --target=tb_aes_key_mem $VLNV
+      - run: fusesoc run --target=tb_aes $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : aes
+      VLNV : secworks:crypto:aes
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: aes
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV
+    

--- a/.github/workflows/openlane_runner.py
+++ b/.github/workflows/openlane_runner.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+#This script is a launcher script for Edalize
+#Normally Edalize will launch the EDA tools directly, but if the
+#EDALIZE_LAUNCHER environmnet variable is set and points to an executable file,
+#this file will be called with the command-line that Edalize would otherwise
+#have launched.
+#
+#This allows us to define a custom launcher, as in this case where we intercept
+#the call to flow.tcl (the entry point to the openlane flow) and start up a
+#container. If Edalize wants to execute other applications, we just start them
+#the normal way
+
+import os
+import subprocess
+import sys
+
+def enverr(e):
+    print(f"Error: Openlane backend needs environment variable '{e}' to be set")
+    exit(1)
+
+if 'flow.tcl' in sys.argv[1]:
+    pdk_root      = os.environ.get('PDK_ROOT') or enverr('PDK_ROOT')
+    (build_root, work) = os.path.split(os.getcwd())
+
+    image = "efabless/openlane:v0.12"
+
+    prefix = ["docker", "run",
+              "-v", f"{pdk_root}:{pdk_root}",
+              "-v", f"{build_root}:/project",
+              "-e", f"PDK_ROOT={pdk_root}",
+              "-u", f"{os.getuid()}:{os.getgid()}",
+              "-w", f"/project/{work}",
+              image]
+    sys.exit(subprocess.call(prefix+sys.argv[1:]))
+else:
+    sys.exit(subprocess.call(sys.argv[1:]))
+    

--- a/aes.core
+++ b/aes.core
@@ -1,0 +1,64 @@
+CAPI=2:
+
+name : secworks:crypto:aes:0
+
+filesets:
+  rtl:
+    files:
+      - src/rtl/aes_core.v
+      - src/rtl/aes.v
+      - src/rtl/aes_key_mem.v
+      - src/rtl/aes_encipher_block.v
+      - src/rtl/aes_inv_sbox.v
+      - src/rtl/aes_sbox.v
+      - src/rtl/aes_decipher_block.v
+    file_type : verilogSource
+
+  tb:
+    files:
+      - src/tb/tb_aes.v
+      - src/tb/tb_aes_key_mem.v
+      - src/tb/tb_aes_core.v
+      - src/tb/tb_aes_decipher_block.v
+      - src/tb/tb_aes_encipher_block.v
+    file_type : verilogSource
+
+  openlane: {files : [data/sky130.tcl : {file_type : tclSource}]}
+
+targets:
+  default:
+    filesets: [rtl]
+
+  lint:
+    default_tool : verilator
+    filesets : [rtl]
+    tools:
+      verilator:
+        mode : lint-only
+    toplevel : aes
+
+  sky130:
+    default_tool: openlane
+    filesets: [rtl, openlane]
+    toplevel: aes
+
+  tb_aes: &tb
+    default_tool: icarus
+    filesets: [rtl, tb]
+    toplevel : tb_aes
+
+  tb_aes_key_mem:
+    <<: *tb
+    toplevel : tb_aes_key_mem
+
+  tb_aes_core:
+    <<: *tb
+    toplevel : tb_aes_core
+
+  tb_aes_decipher_block:
+    <<: *tb
+    toplevel : tb_aes_decipher_block
+
+  tb_aes_encipher_block:
+    <<: *tb
+    toplevel : tb_aes_encipher_block

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,8 @@
+
+# Design
+set ::env(CLOCK_PORT) "clk"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)
+set ::env(FP_CORE_UTIL) 20
+set ::env(SYNTH_MAX_FANOUT) 8
+set ::env(PL_TARGET_DENSITY) 0.25
+set ::env(CLOCK_PERIOD) "25.9"


### PR DESCRIPTION
This adds a core description file for the aes core that exposes
targets for linting, all five testbenches and for building a GDSII
using OpenLANE. All targets also implemented as Github actions so
that they get run on every push to the repo. Quick FuseSoC instructions

 #install FuseSoC
 pip install fusesoc
 #Create and enter a new workspace
 mkdir workspace && cd workspace
 #Register aes as a library in the workspace
 fusesoc library add aes /path/to/aes
 #...if repo is available locally or...
 fusesoc library add aes https://github.com/secworks/aes
 #...to get the upstream repo
 #To run lint
 fusesoc run --target=lint secworks:crypto:aes
 #Run tb_aes testbench
 fusesoc run --target=tb_aes secworks:crypto:aes
 #Run with modelsim instead of default tool (icarus)
 fusesoc run --target=tb_aes --tool=modelsim secworks:crypto:aes
 #List all targets
 fusesoc core show secworks:crypto:aes